### PR TITLE
Fix strage verbose file path output. https://github.com/julius-speech/segmentation-kit/issues/1

### DIFF
--- a/segment_julius.pl
+++ b/segment_julius.pl
@@ -73,8 +73,8 @@ while ($f = readdir $dh) {
     next unless $f =~ /\.(wav|WAV)$/;
     $filepath = "$datadir/$f";
     next unless -f $filepath;
-    ($basename, $datadir, $ext) = fileparse($filepath, qr/\..*$/);
-    push(@files, $datadir . $basename);
+    ($basename) = (fileparse($filepath, qr/\..*$/))[0];
+    push(@files, "$datadir/$basename");
 }
 closedir $dh;
 


### PR DESCRIPTION
This pull request will fix following issue.
https://github.com/julius-speech/segmentation-kit/issues/1

The problem is that `$datadir` was overwritten by the accident.

``` perl
@files = ();
opendir $dh, $datadir or die "$!:$datadir";
while ($f = readdir $dh) {
    next unless $f =~ /\.(wav|WAV)$/;
    $filepath = "$datadir/$f";
    next unless -f $filepath;
    # ↓ FIX: It overwrites $datadir!
    ($basename, $datadir, $ext) = fileparse($filepath, qr/\..*$/);
    push(@files, $datadir . $basename);
}
```

The output will be like following.
We can see it prints simple path for `./wav/a02.wav` and `./wav/a01.wav`.

```
./wav/a02.wav
enter filename->..................................................................................
...............................................................................................................................................................................................................................enter filename->1 files processed                                      Result saved in "./wav/a02.lab".
./wav/a01.wav
enter filename->..................................................................................
............................................................................................................................................................................................................................................................................................................................................................................enter filename->1 files processed                                                                                             Result saved in "./wav/a01.lab".

```
